### PR TITLE
fix Conflicting getter definitions for property "OPPOChannelID": io.g…

### DIFF
--- a/src/main/java/io/github/doocs/im/model/request/AndroidInfo.java
+++ b/src/main/java/io/github/doocs/im/model/request/AndroidInfo.java
@@ -21,7 +21,7 @@ public class AndroidInfo {
     @JsonProperty("OPPOChannelID")
     private String oppoChannelId;
 
-    @JsonProperty("OPPOChannelID")
+    @JsonProperty("GoogleChannelID")
     private String googleChannelId;
 
     @JsonProperty("VIVOClassification")


### PR DESCRIPTION
…ithub.doocs.im.model.request.AndroidInfo#getOppoChannelId(0 params) vs io.github.doocs.im.model.request.AndroidInfo#getGoogleChannelId(0 params)

issue：https://github.com/doocs/qcloud-im-server-sdk-java/issues/82