### PR TITLE
feat:Improve okhttp retry issues

### DIFF
--- a/src/main/java/io/github/doocs/im/ClientConfiguration.java
+++ b/src/main/java/io/github/doocs/im/ClientConfiguration.java
@@ -23,6 +23,11 @@ public class ClientConfiguration {
     public static final int DEFAULT_MAX_RETRIES = 3;
 
     /**
+     * 默认重试间隔时间（毫秒）
+     */
+    public static final long DEFAULT_RETRY_INTERVAL_MS = 1_000;
+
+    /**
      * 默认自动更新签名
      */
     public static final boolean DEFAULT_RENEW_SIG = true;
@@ -45,6 +50,7 @@ public class ClientConfiguration {
     public static final ConnectionPool DEFAULT_CONNECTION_POOL = new ConnectionPool();
 
     private int maxRetries = DEFAULT_MAX_RETRIES;
+    private long retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS;
     private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private long readTimeout = DEFAULT_READ_TIMEOUT;
     private long writeTimeout = DEFAULT_WRITE_TIMEOUT;
@@ -57,13 +63,14 @@ public class ClientConfiguration {
     public ClientConfiguration() {
     }
 
-    public ClientConfiguration(int maxRetries, long connectTimeout, long readTimeout, long writeTimeout,
+    public ClientConfiguration(int maxRetries, long retryIntervalMs, long connectTimeout, long readTimeout, long writeTimeout,
                                long callTimeout, long expireTime, boolean autoRenewSig,
                                String userAgent, ConnectionPool connectionPool) {
         if (connectionPool == null) {
             connectionPool = DEFAULT_CONNECTION_POOL;
         }
         this.maxRetries = Math.max(0, maxRetries);
+        this.retryIntervalMs = retryIntervalMs;
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
         this.writeTimeout = writeTimeout;
@@ -76,6 +83,7 @@ public class ClientConfiguration {
 
     private ClientConfiguration(Builder builder) {
         this.maxRetries = builder.maxRetries;
+        this.retryIntervalMs = builder.retryIntervalMs;
         this.connectTimeout = builder.connectTimeout;
         this.readTimeout = builder.readTimeout;
         this.writeTimeout = builder.writeTimeout;
@@ -96,6 +104,14 @@ public class ClientConfiguration {
 
     public void setMaxRetries(int maxRetries) {
         this.maxRetries = Math.max(0, maxRetries);
+    }
+
+    public long getRetryIntervalMs() {
+        return retryIntervalMs;
+    }
+
+    public void setRetryIntervalMs(long retryIntervalMs) {
+        this.retryIntervalMs = retryIntervalMs;
     }
 
     public long getConnectTimeout() {
@@ -178,6 +194,9 @@ public class ClientConfiguration {
         if (maxRetries != that.maxRetries) {
             return false;
         }
+        if (retryIntervalMs != that.retryIntervalMs) {
+            return false;
+        }
         if (connectTimeout != that.connectTimeout) {
             return false;
         }
@@ -204,11 +223,12 @@ public class ClientConfiguration {
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxRetries, connectTimeout, readTimeout, writeTimeout, callTimeout, expireTime, autoRenewSig, userAgent, connectionPool);
+        return Objects.hash(maxRetries, retryIntervalMs, connectTimeout, readTimeout, writeTimeout, callTimeout, expireTime, autoRenewSig, userAgent, connectionPool);
     }
 
     public static final class Builder {
         private int maxRetries = DEFAULT_MAX_RETRIES;
+        private long retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS;
         private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
         private long readTimeout = DEFAULT_READ_TIMEOUT;
         private long writeTimeout = DEFAULT_WRITE_TIMEOUT;
@@ -227,6 +247,11 @@ public class ClientConfiguration {
 
         public Builder maxRetries(int maxRetries) {
             this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder retryIntervalMs(int retryIntervalMs) {
+            this.retryIntervalMs = retryIntervalMs;
             return this;
         }
 

--- a/src/main/java/io/github/doocs/im/ClientConfiguration.java
+++ b/src/main/java/io/github/doocs/im/ClientConfiguration.java
@@ -1,167 +1,301 @@
-package io.github.doocs.im.util;
+package io.github.doocs.im;
 
-import io.github.doocs.im.ClientConfiguration;
-import okhttp3.*;
+import io.github.doocs.im.util.VersionInfoUtil;
+import okhttp3.ConnectionPool;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Objects;
 
 /**
- * HTTP 工具类
+ * 客户端配置类
  *
  * @author bingo
- * @since 2021/10/31 15:57
+ * @since 2021/11/2 14:17
  */
-public class HttpUtil {
-    private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+public class ClientConfiguration {
+    /**
+     * 默认 UA
+     */
+    public static final String DEFAULT_USER_AGENT = VersionInfoUtil.getDefaultUserAgent();
 
-    private static final String USER_AGENT_KEY = "User-Agent";
-    private static final ClientConfiguration DEFAULT_CONFIG = new ClientConfiguration();
-    private static final String DEFAULT_USER_AGENT = DEFAULT_CONFIG.getUserAgent();
-    private static final Map<ClientConfiguration, OkHttpClient> CLIENT_CACHE = new ConcurrentHashMap<>();
+    /**
+     * 默认最大重试次数
+     */
+    public static final int DEFAULT_MAX_RETRIES = 3;
 
-    private static final OkHttpClient DEFAULT_CLIENT = new OkHttpClient.Builder()
-            .connectionPool(DEFAULT_CONFIG.getConnectionPool())
-            .connectTimeout(DEFAULT_CONFIG.getConnectTimeout(), TimeUnit.MILLISECONDS)
-            .readTimeout(DEFAULT_CONFIG.getReadTimeout(), TimeUnit.MILLISECONDS)
-            .writeTimeout(DEFAULT_CONFIG.getWriteTimeout(), TimeUnit.MILLISECONDS)
-            .callTimeout(DEFAULT_CONFIG.getCallTimeout(), TimeUnit.MILLISECONDS)
-            .retryOnConnectionFailure(false)
-            .addInterceptor(new RetryInterceptor(DEFAULT_CONFIG.getMaxRetries(), DEFAULT_CONFIG.getRetryIntervalMs()))
-            .build();
+    /**
+     * 默认重试间隔时间（毫秒）
+     */
+    public static final long DEFAULT_RETRY_INTERVAL_MS = 100;
 
-    private HttpUtil() {
+    /**
+     * 默认自动更新签名
+     */
+    public static final boolean DEFAULT_RENEW_SIG = true;
+    /**
+     * 默认超时时间（毫秒）
+     */
+    public static final long DEFAULT_CONNECT_TIMEOUT = 10_000;
+    public static final long DEFAULT_READ_TIMEOUT = 10_000;
+    public static final long DEFAULT_WRITE_TIMEOUT = 10_000;
+    public static final long DEFAULT_CALL_TIMEOUT = 30_000;
 
+    /**
+     * UserSig 签名默认有效时长（秒）
+     */
+    public static final long DEFAULT_EXPIRE_TIME = 24 * 60 * 60L;
+
+    /**
+     * 默认okhttp3连接池
+     */
+    public static final ConnectionPool DEFAULT_CONNECTION_POOL = new ConnectionPool();
+
+    private int maxRetries = DEFAULT_MAX_RETRIES;
+    private long retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS;
+    private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+    private long readTimeout = DEFAULT_READ_TIMEOUT;
+    private long writeTimeout = DEFAULT_WRITE_TIMEOUT;
+    private long callTimeout = DEFAULT_CALL_TIMEOUT;
+    private long expireTime = DEFAULT_EXPIRE_TIME;
+    private boolean autoRenewSig = DEFAULT_RENEW_SIG;
+    private String userAgent = DEFAULT_USER_AGENT;
+    private ConnectionPool connectionPool = DEFAULT_CONNECTION_POOL;
+
+    public ClientConfiguration() {
     }
 
-    public static String post(String url, String json, ClientConfiguration config) throws IOException {
-        OkHttpClient httpClient = getClient(config);
-        Map<String, String> headers = new HashMap<>(2);
-        boolean emptyAgent = Objects.isNull(config) || Objects.isNull(config.getUserAgent());
-        headers.put(USER_AGENT_KEY, emptyAgent ? DEFAULT_USER_AGENT : config.getUserAgent());
-        return post(url, json, httpClient, headers);
-    }
-
-    private static OkHttpClient getClient(ClientConfiguration config) {
-        if (config == null) {
-            return DEFAULT_CLIENT;
+    public ClientConfiguration(int maxRetries, long retryIntervalMs, long connectTimeout, long readTimeout, long writeTimeout,
+                               long callTimeout, long expireTime, boolean autoRenewSig,
+                               String userAgent, ConnectionPool connectionPool) {
+        if (connectionPool == null) {
+            connectionPool = DEFAULT_CONNECTION_POOL;
         }
-
-        return CLIENT_CACHE.computeIfAbsent(config, cfg -> new OkHttpClient.Builder()
-                .connectionPool(cfg.getConnectionPool())
-                .connectTimeout(cfg.getConnectTimeout(), TimeUnit.MILLISECONDS)
-                .readTimeout(cfg.getReadTimeout(), TimeUnit.MILLISECONDS)
-                .writeTimeout(cfg.getWriteTimeout(), TimeUnit.MILLISECONDS)
-                .callTimeout(cfg.getCallTimeout(), TimeUnit.MILLISECONDS)
-                .retryOnConnectionFailure(false)
-                .addInterceptor(new RetryInterceptor(cfg.getMaxRetries(), cfg.getRetryIntervalMs()))
-                .build());
+        this.maxRetries = Math.max(0, maxRetries);
+        this.retryIntervalMs = retryIntervalMs;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+        this.writeTimeout = writeTimeout;
+        this.callTimeout = callTimeout;
+        this.expireTime = expireTime;
+        this.autoRenewSig = autoRenewSig;
+        this.userAgent = userAgent;
+        this.connectionPool = connectionPool;
     }
 
-    public static String post(String url, String json, OkHttpClient httpClient, Map<String, String> headers) throws IOException {
-        RequestBody body = RequestBody.create(json, JSON);
-        Headers.Builder hb = new Headers.Builder();
-        if (headers != null && !headers.isEmpty()) {
-            headers.forEach(hb::add);
-        }
-        Request request = new Request.Builder()
-                .url(url)
-                .headers(hb.build())
-                .post(body)
-                .build();
-        try (Response response = httpClient.newCall(request).execute()) {
-            return Objects.requireNonNull(response.body()).string();
-        }
+    private ClientConfiguration(Builder builder) {
+        this.maxRetries = builder.maxRetries;
+        this.retryIntervalMs = builder.retryIntervalMs;
+        this.connectTimeout = builder.connectTimeout;
+        this.readTimeout = builder.readTimeout;
+        this.writeTimeout = builder.writeTimeout;
+        this.callTimeout = builder.callTimeout;
+        this.expireTime = builder.expireTime;
+        this.autoRenewSig = builder.autoRenewSig;
+        this.userAgent = builder.userAgent;
+        this.connectionPool = builder.connectionPool;
     }
 
-    public static <T> T post(String url, Object data, Class<T> cls, ClientConfiguration config) throws IOException {
-        String result = post(url, JsonUtil.obj2Str(data), config);
-        return JsonUtil.str2Obj(result, cls);
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public static <T> T post(String url, Object data, Class<T> cls) throws IOException {
-        return post(url, data, cls, null);
+    public int getMaxRetries() {
+        return maxRetries;
     }
 
-    public static String get(String url) throws IOException {
-        Request request = new Request.Builder()
-                .url(url)
-                .build();
-        try (Response response = DEFAULT_CLIENT.newCall(request).execute()) {
-            return Objects.requireNonNull(response.body()).string();
-        }
+    public void setMaxRetries(int maxRetries) {
+        this.maxRetries = Math.max(0, maxRetries);
     }
-}
 
-class RetryInterceptor implements Interceptor {
-    private static final Set<Integer> RETRYABLE_STATUS_CODES = Collections.unmodifiableSet(
-            Stream.of(408, 429, 500, 502, 503, 504).collect(Collectors.toSet())
-    );
-    private static final int MAX_DELAY_MS = 10000;
-    private final int maxRetries;
-    private final long retryIntervalMs;
+    public long getRetryIntervalMs() {
+        return retryIntervalMs;
+    }
 
-    public RetryInterceptor(int maxRetries, long retryIntervalMs) {
-        this.maxRetries = maxRetries;
+    public void setRetryIntervalMs(long retryIntervalMs) {
         this.retryIntervalMs = retryIntervalMs;
     }
 
-    @Override
-    public Response intercept(Chain chain) throws IOException {
-        Request request = chain.request();
-        Response response = null;
-        IOException exception = null;
-        for (int attempt = 0; attempt <= maxRetries; ++attempt) {
-            if (response != null) {
-                response.close();
-            }
-            try {
-                response = chain.proceed(request);
-                if (response.isSuccessful()) {
-                    return response;
-                }
-                if (!shouldRetry(response)) {
-                    return response;
-                }
-            } catch (IOException e) {
-                if (attempt >= maxRetries) {
-                    throw e;
-                }
-                exception = e;
-            }
-            if (attempt < maxRetries) {
-                waitForRetry(attempt);
-            }
-        }
-
-        if (response != null) {
-            return response;
-        }
-        if (exception != null) {
-            throw exception;
-        } else {
-            throw new IOException("Failed to get a valid response after all retries and no exception was caught.");
-        }
+    public long getConnectTimeout() {
+        return connectTimeout;
     }
 
-    private boolean shouldRetry(Response response) {
-        final int code = response.code();
-        if (code >= 500 && code < 600) {
+    public void setConnectTimeout(long connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public long getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(long readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public long getWriteTimeout() {
+        return writeTimeout;
+    }
+
+    public void setWriteTimeout(long writeTimeout) {
+        this.writeTimeout = writeTimeout;
+    }
+
+    public long getCallTimeout() {
+        return callTimeout;
+    }
+
+    public void setCallTimeout(long callTimeout) {
+        this.callTimeout = callTimeout;
+    }
+
+    public long getExpireTime() {
+        return expireTime;
+    }
+
+    public void setExpireTime(long expireTime) {
+        this.expireTime = expireTime;
+    }
+
+    public boolean isAutoRenewSig() {
+        return autoRenewSig;
+    }
+
+    public void setAutoRenewSig(boolean autoRenewSig) {
+        this.autoRenewSig = autoRenewSig;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    public ConnectionPool getConnectionPool() {
+        return connectionPool;
+    }
+
+    public void setConnectionPool(ConnectionPool connectionPool) {
+        if (connectionPool == null) {
+            connectionPool = DEFAULT_CONNECTION_POOL;
+        }
+        this.connectionPool = connectionPool;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        return RETRYABLE_STATUS_CODES.contains(code);
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClientConfiguration that = (ClientConfiguration) o;
+        if (maxRetries != that.maxRetries) {
+            return false;
+        }
+        if (retryIntervalMs != that.retryIntervalMs) {
+            return false;
+        }
+        if (connectTimeout != that.connectTimeout) {
+            return false;
+        }
+        if (readTimeout != that.readTimeout) {
+            return false;
+        }
+        if (writeTimeout != that.writeTimeout) {
+            return false;
+        }
+        if (callTimeout != that.callTimeout) {
+            return false;
+        }
+        if (expireTime != that.expireTime) {
+            return false;
+        }
+        if (autoRenewSig != that.autoRenewSig) {
+            return false;
+        }
+        if (!userAgent.equals(that.userAgent)) {
+            return false;
+        }
+        return connectionPool.equals(that.connectionPool);
     }
 
-    private void waitForRetry(int attempt) {
-        try {
-            final long delayMs = Math.min(MAX_DELAY_MS, retryIntervalMs * (1L << attempt));
-            TimeUnit.MILLISECONDS.sleep(delayMs);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+    @Override
+    public int hashCode() {
+        return Objects.hash(maxRetries, retryIntervalMs, connectTimeout, readTimeout, writeTimeout, callTimeout, expireTime, autoRenewSig, userAgent, connectionPool);
+    }
+
+    public static final class Builder {
+        private int maxRetries = DEFAULT_MAX_RETRIES;
+        private long retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS;
+        private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+        private long readTimeout = DEFAULT_READ_TIMEOUT;
+        private long writeTimeout = DEFAULT_WRITE_TIMEOUT;
+        private long callTimeout = DEFAULT_CALL_TIMEOUT;
+        private long expireTime = DEFAULT_EXPIRE_TIME;
+        private boolean autoRenewSig = DEFAULT_RENEW_SIG;
+        private String userAgent = DEFAULT_USER_AGENT;
+        private ConnectionPool connectionPool = DEFAULT_CONNECTION_POOL;
+
+        private Builder() {
+        }
+
+        public ClientConfiguration build() {
+            return new ClientConfiguration(this);
+        }
+
+        public Builder maxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder retryIntervalMs(int retryIntervalMs) {
+            this.retryIntervalMs = retryIntervalMs;
+            return this;
+        }
+
+        public Builder connectTimeout(long connectTimeout) {
+            this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        public Builder readTimeout(long readTimeout) {
+            this.readTimeout = readTimeout;
+            return this;
+        }
+
+        public Builder writeTimeout(long writeTimeout) {
+            this.writeTimeout = writeTimeout;
+            return this;
+        }
+
+        public Builder callTimeout(long callTimeout) {
+            this.callTimeout = callTimeout;
+            return this;
+        }
+
+        public Builder expireTime(long expireTime) {
+            this.expireTime = expireTime;
+            return this;
+        }
+
+        public Builder autoRenewSig(boolean autoRenewSig) {
+            this.autoRenewSig = autoRenewSig;
+            return this;
+        }
+
+        public Builder userAgent(String userAgent) {
+            this.userAgent = userAgent;
+            return this;
+        }
+
+        public Builder connectionPool(ConnectionPool connectionPool) {
+            if (connectionPool == null) {
+                connectionPool = DEFAULT_CONNECTION_POOL;
+            }
+            this.connectionPool = connectionPool;
+            return this;
         }
     }
 }

--- a/src/main/java/io/github/doocs/im/ClientConfiguration.java
+++ b/src/main/java/io/github/doocs/im/ClientConfiguration.java
@@ -25,7 +25,7 @@ public class ClientConfiguration {
     /**
      * 默认重试间隔时间（毫秒）
      */
-    public static final long DEFAULT_RETRY_INTERVAL_MS = 100;
+    public static final long DEFAULT_RETRY_INTERVAL_MS = 200;
 
     /**
      * 默认自动更新签名

--- a/src/main/java/io/github/doocs/im/util/HttpUtil.java
+++ b/src/main/java/io/github/doocs/im/util/HttpUtil.java
@@ -31,7 +31,7 @@ public class HttpUtil {
             .writeTimeout(DEFAULT_CONFIG.getWriteTimeout(), TimeUnit.MILLISECONDS)
             .callTimeout(DEFAULT_CONFIG.getCallTimeout(), TimeUnit.MILLISECONDS)
             .retryOnConnectionFailure(false)
-            .addInterceptor(new RetryInterceptor(DEFAULT_CONFIG.getMaxRetries()))
+            .addInterceptor(new RetryInterceptor(DEFAULT_CONFIG.getMaxRetries(), DEFAULT_CONFIG.getRetryIntervalMs()))
             .build();
 
     private HttpUtil() {
@@ -58,7 +58,7 @@ public class HttpUtil {
                 .writeTimeout(cfg.getWriteTimeout(), TimeUnit.MILLISECONDS)
                 .callTimeout(cfg.getCallTimeout(), TimeUnit.MILLISECONDS)
                 .retryOnConnectionFailure(false)
-                .addInterceptor(new RetryInterceptor(cfg.getMaxRetries()))
+                .addInterceptor(new RetryInterceptor(cfg.getMaxRetries(), cfg.getRetryIntervalMs()))
                 .build());
     }
 
@@ -98,28 +98,71 @@ public class HttpUtil {
 }
 
 class RetryInterceptor implements Interceptor {
-    private int maxRetry;
 
-    RetryInterceptor(int maxRetry) {
-        this.maxRetry = maxRetry;
-    }
+    private static final int[] RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504};
+    private final int maxRetries;
+    private final long retryIntervalMs;
 
-    public int getMaxRetry() {
-        return maxRetry;
-    }
-
-    public void setMaxRetry(int maxRetry) {
-        this.maxRetry = maxRetry;
+    public RetryInterceptor(int maxRetries, long retryIntervalMs) {
+        this.maxRetries = maxRetries;
+        this.retryIntervalMs = retryIntervalMs;
     }
 
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
-        Response response = chain.proceed(request);
-        for (int i = 0; i < maxRetry && !response.isSuccessful(); ++i) {
-            response.close();
-            response = chain.proceed(request);
+        Response response = null;
+        IOException exception = null;
+        int attempt = 0;
+        while (attempt <= maxRetries) {
+            if (response != null) {
+                response.close();
+            }
+            try {
+                response = chain.proceed(request);
+                if (response.isSuccessful()) {
+                    return response;
+                }
+                if (!shouldRetry(response)) {
+                    return response;
+                }
+            } catch (IOException e) {
+                if (attempt == maxRetries) {
+                    throw e;
+                }
+                exception = e;
+            }
+            if (attempt < maxRetries) {
+                waitForRetry(attempt);
+            }
+            attempt++;
         }
-        return response;
+
+        if (response != null) {
+            return response;
+        } else {
+            if (exception != null) {
+                throw exception;
+            } else {
+                throw new IOException("Failed to get a valid response after all retries and no exception was caught.");
+            }
+        }
+    }
+
+    private boolean shouldRetry(Response response) {
+        final int code = response.code();
+        for (int retryableCode : RETRYABLE_STATUS_CODES) {
+            if (code == retryableCode) return true;
+        }
+        return (code >= 500 && code < 600);
+    }
+
+    private void waitForRetry(int attempt) {
+        try {
+            final long delayMs = retryIntervalMs * (1L << attempt);
+            TimeUnit.MILLISECONDS.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/java/io/github/doocs/im/util/HttpUtil.java
+++ b/src/main/java/io/github/doocs/im/util/HttpUtil.java
@@ -101,6 +101,7 @@ class RetryInterceptor implements Interceptor {
     private static final Set<Integer> RETRYABLE_STATUS_CODES = Collections.unmodifiableSet(
             Stream.of(408, 429, 500, 502, 503, 504).collect(Collectors.toSet())
     );
+    private static final int MAX_DELAY_MS = 10000;
     private final int maxRetries;
     private final long retryIntervalMs;
 
@@ -157,7 +158,7 @@ class RetryInterceptor implements Interceptor {
 
     private void waitForRetry(int attempt) {
         try {
-            final long delayMs = retryIntervalMs * (1L << attempt);
+            final long delayMs = Math.min(MAX_DELAY_MS, retryIntervalMs * (1L << attempt));
             TimeUnit.MILLISECONDS.sleep(delayMs);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
一、异常处理优化：
1、捕获chain.proceed()可能抛出的IOException
2、仅在达到最大重试次数时抛出异常
3、保留最后一次异常供最终抛出
二、智能重试策略：
1、新增shouldRetry方法，只对以下情况重试：
     a：5xx服务器错误
     b：408请求超时
     c：429请求过多
     d：502错误网关
     e：503服务不可用
     f：504网关超时
三、指数退避机制：
1、使用retryIntervalMs * 2^attempt实现指数退避
2、避免立即重试导致服务器压力过大
3、可通过构造函数配置基础等待时间
四、资源管理优化：
1、每次重试前显式关闭之前的响应
2、确保响应体资源及时释放
五、循环逻辑改进：
1、使用attempt <= maxRetries条件
2、包含首次请求在内的完整重试周期
3、更清晰的尝试次数控制
六、新增配置参数：
1、retryIntervalMs可配置基础等待时间
2、保持线程中断状态（正确处理InterruptedException）